### PR TITLE
NMS, Kalman, Mahalanobis / 칼만 바운더리와 예측 바운더리의 편차 거리 계산

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCE
     src/main.cpp
     src/heatmap_generator.cpp
     src/tvm_wrapper.cpp
+    src/tracker.cpp
 )
 
 add_executable(tvm_tutorial ${SOURCE})

--- a/include/heatmap_generator.h
+++ b/include/heatmap_generator.h
@@ -8,7 +8,8 @@ class HeatMapGenerator {
         HeatMapGenerator();
         ~HeatMapGenerator();
 
-        cv::Mat generateHeatmap(cv::Mat& frame, int x1, int y1, int x2, int y2);
+        float IOU(const cv::Rect& box1, const cv::Rect& box2);
+        std::vector<int> NonMaximumSuppression(const std::vector<cv::Rect>& boxes, const std::vector<float>& confidences, float iou_threshold); int x1, int y1, int x2, int y2);
 
 };
 

--- a/include/tracker.h
+++ b/include/tracker.h
@@ -1,0 +1,15 @@
+#ifndef __TRACKER__
+#define __TRACKER__
+
+#include <opencv2/opencv.hpp>
+
+
+class Tracker {
+    public:
+        cv::KalmanFilter baseKalman();
+        double mahalanobis_distance(const cv::Point predicted_center, const cv::Point detected_center, const cv::Mat& invCovariance);
+
+
+};
+
+#endif // __TRACKER__

--- a/include/tvm_wrapper.h
+++ b/include/tvm_wrapper.h
@@ -9,6 +9,8 @@
 #include <tvm/runtime/ndarray.h>
 #include <opencv2/opencv.hpp>
 
+#include "tracker.h"
+
 
 // 예시 코코 데이터 셋 설정
 const static std::vector<std::string> COCO_CLASS = {
@@ -40,6 +42,7 @@ class TVMWrapper {
         };
 
         void detect();
+        void detect_video(const std::string video_path);
         tvm::runtime::NDArray preprocess_frame(cv::Mat& frame,int _batch, int _input_w, int _input_h);
 
     private:

--- a/src/heatmap_generator.cpp
+++ b/src/heatmap_generator.cpp
@@ -8,8 +8,52 @@ HeatMapGenerator::~HeatMapGenerator() {
     
 }
 
-cv::Mat HeatMapGenerator::generateHeatmap(cv::Mat& frame, int x1, int y1, int x2, int y2)
-{
-    cv::rectangle(frame, cv::Point(x1, y1), cv::Point(x2, y2), cv::Scalar(0, 255), 1);
+// cv::Mat HeatMapGenerator::generateHeatmap(cv::Mat& frame, int x1, int y1, int x2, int y2)
+// {
+//     cv::rectangle(frame, cv::Point(x1, y1), cv::Point(x2, y2), cv::Scalar(0, 255), 1);
+// }
+
+
+float HeatMapGenerator::IOU(const cv::Rect& box1, const cv::Rect& box2) {
+    int x1 = std::max(box1.x, box2.x);
+    int y1 = std::max(box1.y, box2.y);
+    int x2 = std::min(box1.x + box1.width, box2.x + box2.width);
+    int y2 = std::min(box1.y + box1.height, box2.y + box2.height);
+
+    int interArea = std::max(0, x2 - x1) * std::max(0, y2 - y1);
+    int box1Area = box1.width * box1.height;
+    int box2Area = box2.width * box2.height;
+
+    return static_cast<float>(interArea) / (box1Area + box2Area - interArea);
 }
 
+std::vector<int> HeatMapGenerator::NonMaximumSuppression(const std::vector<cv::Rect>& boxes, const std::vector<float>& confidences, float iou_threshold) {
+    std::vector<int> indices;
+    std::vector<int> sorted_indices(boxes.size());
+
+    for (int i = 0; i < boxes.size(); ++i) {
+        sorted_indices[i] = i;
+    }
+    std::sort(sorted_indices.begin(), sorted_indices.end(), [&](int i, int j) {
+        return confidences[i] > confidences[j];
+    });
+
+    std::vector<bool> suppressed(boxes.size(), false);
+    for (int i = 0; i < sorted_indices.size(); ++i) {
+        int idx = sorted_indices[i];
+        if (suppressed[idx]) continue;
+
+        indices.push_back(idx);
+
+        for (int j = i + 1; j < sorted_indices.size(); ++j) {
+            int next_idx = sorted_indices[j];
+            if (suppressed[next_idx]) continue;
+
+            // IoU 계산 후 겹치면 suppress
+            if (IOU(boxes[idx], boxes[next_idx]) > iou_threshold) {
+                suppressed[next_idx] = true;
+            }
+        }
+    }
+    return indices;
+}


### PR DESCRIPTION
NMS : 알고리즘을 따로 구현했으나 cv 에서 grid nms 알고리즘을 제공해 성능 비교 필요.

kalman : strong sort에 있는 base kalman 의 공분산을 참조해 작성

mahalanobis : kalman 의 바운더리와 yolo 모델로 탐지한 detection 바운더리 차이 값을 사용해 편차 계산

추후 해야할 것 : 1.mahalanobis에 대한 검증, 2.cost 측정